### PR TITLE
Add username creation, listing, and verification.

### DIFF
--- a/SERVER/fileops.py
+++ b/SERVER/fileops.py
@@ -36,7 +36,7 @@ class FileOps(object):
     except:
       pass
 
-  def open_contacts(self):
+  def get_contacts(self):
     return self._get_json("contacts") 
 
   def add_contact(self, contact):

--- a/SERVER/main.py
+++ b/SERVER/main.py
@@ -41,7 +41,7 @@ def chatApp():
 def send_images(path):
     return flask.send_from_directory('images', path)
 
-@app.route('/receive_message', methods=['POST'])
+@app.route('/post_message', methods=['POST'])
 def receive_message():
   print(request.json)
   fo.put_messages(request.json)
@@ -51,6 +51,27 @@ def receive_message():
 def get_messages():
   return flask.json.jsonify(result=fo.get_messages())
 
+@app.route('/post_user', methods=['POST'])
+def post_user():
+  print(request.json)
+  fo.add_contact(request.json)
+  return flask.json.jsonify(result=request.json)
+
+@app.route('/get_users', methods=['GET'])
+def get_users():
+  return flask.json.jsonify(result=fo.get_contacts())
+
+@app.route('/verify_user', methods=['POST'])
+def verify_user():
+  retVal = False
+  username = request.json["username"]
+  password = request.json["password"]
+  users = fo.get_contacts()
+  for user, passwd in users:
+    if user == username and passwd == password:
+      retVal = True
+  return flask.json.jsonify(result={"verified": retVal})
+  
 @app.errorhandler(404)
 def page_not_found(error):
     app.logger.debug("Page not found")

--- a/SERVER/static/js/chat.js
+++ b/SERVER/static/js/chat.js
@@ -36,7 +36,7 @@
       /sends packet to Server
       */
       $.ajax({
-          url:'/receive_message',
+          url:'/post_message',
           data: JSON.stringify(packet),
           type: 'POST',
           contentType: 'application/json',


### PR DESCRIPTION
Problem: Currently we have no way to create, list, or verify users.

Solution: Create way to do so.

Endpoint use:
- /post_user:
  - Allows the creation of a user. Post to it.
- /get_users:
  - gets complete list of users
- /verify_user:
  - expects a json packet with username and password (plain text)

Minimum user information:
- Json format
{ "username": "CoolBeans",
  "password": "BadPass"
}

Additional Changes:
- Changed end point for posting messages... no longer retreive message, now it
  is post_message. Updated chat.js to reflect this.